### PR TITLE
Fixed keyswitch enum variables spelling mistakes

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ $ Example: ./build/bin/examples/1_basic_bfv
 
 int main() {
     heongpu::Parameters context(heongpu::scheme_type::bfv,
-            heongpu::keyswitching_type::KEYSWITHING_METHOD_I);
+            heongpu::keyswitching_type::KEYSWITCHING_METHOD_I);
 
     size_t poly_modulus_degree = 8192;
     context.set_poly_modulus_degree(poly_modulus_degree);

--- a/benchmark/benchmark_bfv.cu
+++ b/benchmark/benchmark_bfv.cu
@@ -23,7 +23,7 @@ int main(int argc, char* argv[])
     {
         heongpu::Parameters context(
             heongpu::scheme_type::bfv,
-            heongpu::keyswitching_type::KEYSWITHING_METHOD_I);
+            heongpu::keyswitching_type::KEYSWITCHING_METHOD_I);
         context.set_poly_modulus_degree(poly_modulus_degrees[i]);
         context.set_default_coeff_modulus(1);
         context.set_plain_modulus(plain_modulus[i]);

--- a/benchmark/benchmark_ckks.cu
+++ b/benchmark/benchmark_ckks.cu
@@ -36,7 +36,7 @@ int main(int argc, char* argv[])
     {
         heongpu::Parameters context(
             heongpu::scheme_type::ckks,
-            heongpu::keyswitching_type::KEYSWITHING_METHOD_I,
+            heongpu::keyswitching_type::KEYSWITCHING_METHOD_I,
             heongpu::sec_level_type::none);
         context.set_poly_modulus_degree(poly_modulus_degrees[i]);
         context.set_coeff_modulus(log_Q_bit_sizes[i], log_P_bit_sizes[i]);

--- a/example/1_basic_bfv.cu
+++ b/example/1_basic_bfv.cu
@@ -17,7 +17,7 @@ int main(int argc, char* argv[])
     // Initialize encryption parameters for the BFV scheme.
     heongpu::Parameters context(
         heongpu::scheme_type::bfv,
-        heongpu::keyswitching_type::KEYSWITHING_METHOD_I);
+        heongpu::keyswitching_type::KEYSWITCHING_METHOD_I);
 
     // Set the polynomial modulus degree. This controls the complexity
     // of the computations and the size of the ciphertexts. Larger values
@@ -30,7 +30,7 @@ int main(int argc, char* argv[])
     // sec256, none
     // heongpu::Parameters context(
     //    heongpu::scheme_type::bfv,
-    //    heongpu::keyswitching_type::KEYSWITHING_METHOD_I,
+    //    heongpu::keyswitching_type::KEYSWITCHING_METHOD_I,
     //    heongpu::sec_level_type::sec128);
 
     // Set the coefficient modulus, which determines the size of the noise

--- a/example/2_basic_ckks.cu
+++ b/example/2_basic_ckks.cu
@@ -17,7 +17,7 @@ int main(int argc, char* argv[])
     // Initialize encryption parameters for the CKKS scheme.
     heongpu::Parameters context(
         heongpu::scheme_type::ckks,
-        heongpu::keyswitching_type::KEYSWITHING_METHOD_I);
+        heongpu::keyswitching_type::KEYSWITCHING_METHOD_I);
 
     // Set the polynomial modulus degree. This controls the complexity
     // of the computations and the size of the ciphertexts. Larger values
@@ -30,7 +30,7 @@ int main(int argc, char* argv[])
     // sec256, none
     // heongpu::Parameters context(
     //    heongpu::scheme_type::bfv,
-    //    heongpu::keyswitching_type::KEYSWITHING_METHOD_I,
+    //    heongpu::keyswitching_type::KEYSWITCHING_METHOD_I,
     //    heongpu::sec_level_type::sec128);
 
     // A recommended approach is to align the initial scale and the primes in

--- a/example/3_switchkey_methods_bfv.cu
+++ b/example/3_switchkey_methods_bfv.cu
@@ -13,8 +13,8 @@ int main(int argc, char* argv[])
 
     heongpu::Parameters context(
         heongpu::scheme_type::bfv,
-        heongpu::keyswitching_type::KEYSWITHING_METHOD_I);
-    // heongpu::keyswitching_type::KEYSWITHING_METHOD_III not supports rotation
+        heongpu::keyswitching_type::KEYSWITCHING_METHOD_I);
+    // heongpu::keyswitching_type::KEYSWITCHING_METHOD_III not supports rotation
     // because of key size, only supports relinearization!
 
     size_t poly_modulus_degree = 16384;

--- a/example/4_switchkey_methods_ckks.cu
+++ b/example/4_switchkey_methods_ckks.cu
@@ -14,7 +14,7 @@ int main(int argc, char* argv[])
     // Initialize encryption parameters for the CKKS scheme.
     heongpu::Parameters context(
         heongpu::scheme_type::ckks,
-        heongpu::keyswitching_type::KEYSWITHING_METHOD_II,
+        heongpu::keyswitching_type::KEYSWITCHING_METHOD_II,
         heongpu::sec_level_type::none);
 
     size_t poly_modulus_degree = 16384;

--- a/example/5_default_stream_usage.cu
+++ b/example/5_default_stream_usage.cu
@@ -52,7 +52,7 @@ int main(int argc, char* argv[])
     // Initialize encryption parameters for the CKKS scheme.
     heongpu::Parameters context(
         heongpu::scheme_type::bfv,
-        heongpu::keyswitching_type::KEYSWITHING_METHOD_I);
+        heongpu::keyswitching_type::KEYSWITCHING_METHOD_I);
 
     size_t poly_modulus_degree = 8192;
     int plain_modulus = 786433;

--- a/example/6_multi_stream_usage_way1.cu
+++ b/example/6_multi_stream_usage_way1.cu
@@ -66,7 +66,7 @@ int main(int argc, char* argv[])
     // Initialize encryption parameters for the CKKS scheme.
     heongpu::Parameters context(
         heongpu::scheme_type::bfv,
-        heongpu::keyswitching_type::KEYSWITHING_METHOD_I);
+        heongpu::keyswitching_type::KEYSWITCHING_METHOD_I);
 
     size_t poly_modulus_degree = 8192;
     int plain_modulus = 786433;

--- a/example/7_multi_stream_usage_way2.cu
+++ b/example/7_multi_stream_usage_way2.cu
@@ -61,7 +61,7 @@ int main(int argc, char* argv[])
     // Initialize encryption parameters for the CKKS scheme.
     heongpu::Parameters context(
         heongpu::scheme_type::bfv,
-        heongpu::keyswitching_type::KEYSWITHING_METHOD_I);
+        heongpu::keyswitching_type::KEYSWITCHING_METHOD_I);
 
     size_t poly_modulus_degree = 8192;
     int plain_modulus = 786433;

--- a/src/heongpu/include/host/keygenerator.cuh
+++ b/src/heongpu/include/host/keygenerator.cuh
@@ -80,10 +80,10 @@ namespace heongpu
         {
             switch (static_cast<int>(rk.key_type))
             {
-                case 1: // KEYSWITHING_METHOD_I
+                case 1: // KEYSWITCHING_METHOD_I
                     generate_relin_key_method_I(rk, sk);
                     break;
-                case 2: // KEYSWITHING_METHOD_II
+                case 2: // KEYSWITCHING_METHOD_II
 
                     if (rk.scheme_ == scheme_type::bfv)
                     { // no leveled
@@ -100,7 +100,7 @@ namespace heongpu
                     }
 
                     break;
-                case 3: // KEYSWITHING_METHOD_III
+                case 3: // KEYSWITCHING_METHOD_III
 
                     if (rk.scheme_ == scheme_type::bfv)
                     { // no leveled
@@ -135,10 +135,10 @@ namespace heongpu
         {
             switch (static_cast<int>(gk.key_type))
             {
-                case 1: // KEYSWITHING_METHOD_I
+                case 1: // KEYSWITCHING_METHOD_I
                     generate_galois_key_method_I(gk, sk);
                     break;
-                case 2: // KEYSWITHING_METHOD_II
+                case 2: // KEYSWITCHING_METHOD_II
 
                     if (gk.scheme_ == scheme_type::bfv)
                     {
@@ -155,10 +155,10 @@ namespace heongpu
                     }
 
                     break;
-                case 3: // KEYSWITHING_METHOD_III
+                case 3: // KEYSWITCHING_METHOD_III
 
                     throw std::invalid_argument(
-                        "KEYSWITHING_METHOD_III are not supported because of "
+                        "KEYSWITCHING_METHOD_III are not supported because of "
                         "high memory consumption for galois key generation!");
 
                     break;
@@ -182,10 +182,10 @@ namespace heongpu
         {
             switch (static_cast<int>(swk.key_type))
             {
-                case 1: // KEYSWITHING_METHOD_I
+                case 1: // KEYSWITCHING_METHOD_I
                     generate_switch_key_method_I(swk, new_sk, old_sk);
                     break;
-                case 2: // KEYSWITHING_METHOD_II
+                case 2: // KEYSWITCHING_METHOD_II
 
                     if (swk.scheme_ == scheme_type::bfv)
                     {
@@ -202,10 +202,10 @@ namespace heongpu
                     }
 
                     break;
-                case 3: // KEYSWITHING_METHOD_III
+                case 3: // KEYSWITCHING_METHOD_III
 
                     throw std::invalid_argument(
-                        "KEYSWITHING_METHOD_III are not supported because of "
+                        "KEYSWITCHING_METHOD_III are not supported because of "
                         "high memory consumption for galois key generation!");
 
                     break;

--- a/src/heongpu/include/host/operator.cuh
+++ b/src/heongpu/include/host/operator.cuh
@@ -971,7 +971,7 @@ namespace heongpu
 
             switch (static_cast<int>(relin_key.key_type))
             {
-                case 1: // KEYSWITHING_METHOD_I
+                case 1: // KEYSWITCHING_METHOD_I
                     if (scheme_ == scheme_type::bfv)
                     {
                         if (input1.in_ntt_domain_ != false)
@@ -992,7 +992,7 @@ namespace heongpu
                             "Invalid Key Switching Type");
                     }
                     break;
-                case 2: // KEYSWITHING_METHOD_II
+                case 2: // KEYSWITCHING_METHOD_II
 
                     if (scheme_ == scheme_type::bfv)
                     {
@@ -1017,7 +1017,7 @@ namespace heongpu
                     }
 
                     break;
-                case 3: // KEYSWITHING_METHOD_III
+                case 3: // KEYSWITCHING_METHOD_III
 
                     if (scheme_ == scheme_type::bfv)
                     {
@@ -1078,7 +1078,7 @@ namespace heongpu
 
             switch (static_cast<int>(relin_key.key_type))
             {
-                case 1: // KEYSWITHING_METHOD_I
+                case 1: // KEYSWITCHING_METHOD_I
                     if (scheme_ == scheme_type::bfv)
                     {
                         if (input1.in_ntt_domain_ != false)
@@ -1101,7 +1101,7 @@ namespace heongpu
                             "Invalid Key Switching Type");
                     }
                     break;
-                case 2: // KEYSWITHING_METHOD_II
+                case 2: // KEYSWITCHING_METHOD_II
 
                     if (scheme_ == scheme_type::bfv)
                     {
@@ -1126,7 +1126,7 @@ namespace heongpu
                     }
 
                     break;
-                case 3: // KEYSWITHING_METHOD_III
+                case 3: // KEYSWITCHING_METHOD_III
 
                     if (scheme_ == scheme_type::bfv)
                     {
@@ -1190,7 +1190,7 @@ namespace heongpu
 
             switch (static_cast<int>(galois_key.key_type))
             {
-                case 1: // KEYSWITHING_METHOD_I
+                case 1: // KEYSWITCHING_METHOD_I
                     if (scheme_ == scheme_type::bfv)
                     {
                         if (input1.in_ntt_domain_ != false)
@@ -1211,7 +1211,7 @@ namespace heongpu
                             "Invalid Key Switching Type");
                     }
                     break;
-                case 2: // KEYSWITHING_METHOD_II
+                case 2: // KEYSWITCHING_METHOD_II
                     if (scheme_ == scheme_type::bfv)
                     {
                         if (input1.in_ntt_domain_ != false)
@@ -1233,10 +1233,10 @@ namespace heongpu
                             "Invalid Key Switching Type");
                     }
                     break;
-                case 3: // KEYSWITHING_METHOD_III
+                case 3: // KEYSWITCHING_METHOD_III
 
                     throw std::invalid_argument(
-                        "KEYSWITHING_METHOD_III are not supported because of "
+                        "KEYSWITCHING_METHOD_III are not supported because of "
                         "high memory consumption for rotation operation!");
 
                     break;
@@ -1290,7 +1290,7 @@ namespace heongpu
 
             switch (static_cast<int>(galois_key.key_type))
             {
-                case 1: // KEYSWITHING_METHOD_I
+                case 1: // KEYSWITCHING_METHOD_I
                     if (scheme_ == scheme_type::bfv)
                     {
                         if (input1.in_ntt_domain_ != false)
@@ -1313,7 +1313,7 @@ namespace heongpu
                             "Invalid Key Switching Type");
                     }
                     break;
-                case 2: // KEYSWITHING_METHOD_II
+                case 2: // KEYSWITCHING_METHOD_II
                     if (scheme_ == scheme_type::bfv)
                     {
                         if (input1.in_ntt_domain_ != false)
@@ -1336,10 +1336,10 @@ namespace heongpu
                             "Invalid Key Switching Type");
                     }
                     break;
-                case 3: // KEYSWITHING_METHOD_III
+                case 3: // KEYSWITCHING_METHOD_III
 
                     throw std::invalid_argument(
-                        "KEYSWITHING_METHOD_III are not supported because of "
+                        "KEYSWITCHING_METHOD_III are not supported because of "
                         "high memory consumption for rotation operation!");
 
                     break;
@@ -1420,7 +1420,7 @@ namespace heongpu
 
             switch (static_cast<int>(galois_key.key_type))
             {
-                case 1: // KEYSWITHING_METHOD_I
+                case 1: // KEYSWITCHING_METHOD_I
                     if (scheme_ == scheme_type::bfv)
                     {
                         if (input1.in_ntt_domain_ != false)
@@ -1441,7 +1441,7 @@ namespace heongpu
                             "Invalid Key Switching Type");
                     }
                     break;
-                case 2: // KEYSWITHING_METHOD_II
+                case 2: // KEYSWITCHING_METHOD_II
                     if (scheme_ == scheme_type::bfv)
                     {
                         rotate_columns_method_II(input1, output, galois_key);
@@ -1456,10 +1456,10 @@ namespace heongpu
                             "Invalid Key Switching Type");
                     }
                     break;
-                case 3: // KEYSWITHING_METHOD_III
+                case 3: // KEYSWITCHING_METHOD_III
 
                     throw std::invalid_argument(
-                        "KEYSWITHING_METHOD_III are not supported because of "
+                        "KEYSWITCHING_METHOD_III are not supported because of "
                         "high memory consumption for rotation operation!");
 
                     break;
@@ -1511,7 +1511,7 @@ namespace heongpu
 
             switch (static_cast<int>(galois_key.key_type))
             {
-                case 1: // KEYSWITHING_METHOD_I
+                case 1: // KEYSWITCHING_METHOD_I
                     if (scheme_ == scheme_type::bfv)
                     {
                         if (input1.in_ntt_domain_ != false)
@@ -1533,7 +1533,7 @@ namespace heongpu
                             "Invalid Key Switching Type");
                     }
                     break;
-                case 2: // KEYSWITHING_METHOD_II
+                case 2: // KEYSWITCHING_METHOD_II
                     if (scheme_ == scheme_type::bfv)
                     {
                         rotate_columns_method_II(input1, output, galois_key,
@@ -1549,10 +1549,10 @@ namespace heongpu
                             "Invalid Key Switching Type");
                     }
                     break;
-                case 3: // KEYSWITHING_METHOD_III
+                case 3: // KEYSWITCHING_METHOD_III
 
                     throw std::invalid_argument(
-                        "KEYSWITHING_METHOD_III are not supported because of "
+                        "KEYSWITCHING_METHOD_III are not supported because of "
                         "high memory consumption for rotation operation!");
 
                     break;
@@ -1605,7 +1605,7 @@ namespace heongpu
 
             switch (static_cast<int>(galois_key.key_type))
             {
-                case 1: // KEYSWITHING_METHOD_I
+                case 1: // KEYSWITCHING_METHOD_I
                     if (scheme_ == scheme_type::bfv)
                     {
                         if (input1.in_ntt_domain_ != false)
@@ -1628,7 +1628,7 @@ namespace heongpu
                             "Invalid Key Switching Type");
                     }
                     break;
-                case 2: // KEYSWITHING_METHOD_II
+                case 2: // KEYSWITCHING_METHOD_II
                     if (scheme_ == scheme_type::bfv)
                     {
                         if (input1.in_ntt_domain_ != false)
@@ -1651,10 +1651,10 @@ namespace heongpu
                             "Invalid Key Switching Type");
                     }
                     break;
-                case 3: // KEYSWITHING_METHOD_III
+                case 3: // KEYSWITCHING_METHOD_III
 
                     throw std::invalid_argument(
-                        "KEYSWITHING_METHOD_III are not supported because of "
+                        "KEYSWITCHING_METHOD_III are not supported because of "
                         "high memory consumption for rotation operation!");
 
                     break;
@@ -1710,7 +1710,7 @@ namespace heongpu
 
             switch (static_cast<int>(galois_key.key_type))
             {
-                case 1: // KEYSWITHING_METHOD_I
+                case 1: // KEYSWITCHING_METHOD_I
                     if (scheme_ == scheme_type::bfv)
                     {
                         if (input1.in_ntt_domain_ != false)
@@ -1733,7 +1733,7 @@ namespace heongpu
                             "Invalid Key Switching Type");
                     }
                     break;
-                case 2: // KEYSWITHING_METHOD_II
+                case 2: // KEYSWITCHING_METHOD_II
                     if (scheme_ == scheme_type::bfv)
                     {
                         if (input1.in_ntt_domain_ != false)
@@ -1756,10 +1756,10 @@ namespace heongpu
                             "Invalid Key Switching Type");
                     }
                     break;
-                case 3: // KEYSWITHING_METHOD_III
+                case 3: // KEYSWITCHING_METHOD_III
 
                     throw std::invalid_argument(
-                        "KEYSWITHING_METHOD_III are not supported because of "
+                        "KEYSWITCHING_METHOD_III are not supported because of "
                         "high memory consumption for rotation operation!");
 
                     break;
@@ -1844,7 +1844,7 @@ namespace heongpu
 
             switch (static_cast<int>(switch_key.key_type))
             {
-                case 1: // KEYSWITHING_METHOD_I
+                case 1: // KEYSWITCHING_METHOD_I
                     if (scheme_ == scheme_type::bfv)
                     {
                         if (input1.in_ntt_domain_ != false)
@@ -1865,7 +1865,7 @@ namespace heongpu
                             "Invalid Key Switching Type");
                     }
                     break;
-                case 2: // KEYSWITHING_METHOD_II
+                case 2: // KEYSWITCHING_METHOD_II
                     if (scheme_ == scheme_type::bfv)
                     {
                         if (input1.in_ntt_domain_ != false)
@@ -1886,10 +1886,10 @@ namespace heongpu
                             "Invalid Key Switching Type");
                     }
                     break;
-                case 3: // KEYSWITHING_METHOD_III
+                case 3: // KEYSWITCHING_METHOD_III
 
                     throw std::invalid_argument(
-                        "KEYSWITHING_METHOD_III are not supported because of "
+                        "KEYSWITCHING_METHOD_III are not supported because of "
                         "high memory consumption for keyswitch operation!");
 
                     break;
@@ -1942,7 +1942,7 @@ namespace heongpu
 
             switch (static_cast<int>(switch_key.key_type))
             {
-                case 1: // KEYSWITHING_METHOD_I
+                case 1: // KEYSWITCHING_METHOD_I
                     if (scheme_ == scheme_type::bfv)
                     {
                         if (input1.in_ntt_domain_ != false)
@@ -1964,7 +1964,7 @@ namespace heongpu
                             "Invalid Key Switching Type");
                     }
                     break;
-                case 2: // KEYSWITHING_METHOD_II
+                case 2: // KEYSWITCHING_METHOD_II
                     if (scheme_ == scheme_type::bfv)
                     {
                         if (input1.in_ntt_domain_ != false)
@@ -1986,10 +1986,10 @@ namespace heongpu
                             "Invalid Key Switching Type");
                     }
                     break;
-                case 3: // KEYSWITHING_METHOD_III
+                case 3: // KEYSWITCHING_METHOD_III
 
                     throw std::invalid_argument(
-                        "KEYSWITHING_METHOD_III are not supported because of "
+                        "KEYSWITCHING_METHOD_III are not supported because of "
                         "high memory consumption for keyswitch operation!");
 
                     break;

--- a/src/heongpu/include/util/util.cuh
+++ b/src/heongpu/include/util/util.cuh
@@ -90,9 +90,9 @@ namespace heongpu
     enum class keyswitching_type : std::uint8_t
     {
         NONE = 0x0,
-        KEYSWITHING_METHOD_I = 0x1, // SEALMETHOD = 0x1,
-        KEYSWITHING_METHOD_II = 0x2, // EXTERNALPRODUCT = 0x2,
-        KEYSWITHING_METHOD_III = 0x3, // EXTERNALPRODUCT_2 = 0x3
+        KEYSWITCHING_METHOD_I = 0x1, // SEALMETHOD = 0x1,
+        KEYSWITCHING_METHOD_II = 0x2, // EXTERNALPRODUCT = 0x2,
+        KEYSWITCHING_METHOD_III = 0x3, // EXTERNALPRODUCT_2 = 0x3
     };
 
     enum class storage_type : std::uint8_t

--- a/src/heongpu/lib/host/keyswitch.cu
+++ b/src/heongpu/lib/host/keyswitch.cu
@@ -24,13 +24,13 @@ namespace heongpu
 
         switch (static_cast<int>(context.keyswitching_type_))
         {
-            case 1: // KEYSWITHING_METHOD_I
+            case 1: // KEYSWITCHING_METHOD_I
             {
                 // It can use for both leveled and no leveled.
                 relinkey_size_ = 2 * Q_size_ * Q_prime_size_ * ring_size;
                 break;
             }
-            case 2: // KEYSWITHING_METHOD_II
+            case 2: // KEYSWITCHING_METHOD_II
 
                 if (scheme_ == scheme_type::bfv)
                 { // no leveled
@@ -49,7 +49,7 @@ namespace heongpu
                 }
 
                 break;
-            case 3: // KEYSWITHING_METHOD_III
+            case 3: // KEYSWITCHING_METHOD_III
 
                 if (scheme_ == scheme_type::bfv)
                 { // no leveled
@@ -102,7 +102,7 @@ namespace heongpu
 
         switch (static_cast<int>(context.keyswitching_type_))
         {
-            case 1: // KEYSWITHING_METHOD_I
+            case 1: // KEYSWITCHING_METHOD_I
             {
                 // It can use for both leveled and no leveled.
                 relinkey_size_ = 2 * Q_size_ * Q_prime_size_ * ring_size;
@@ -113,7 +113,7 @@ namespace heongpu
                 device_location_ = DeviceVector<Data>(key);
                 break;
             }
-            case 2: // KEYSWITHING_METHOD_II
+            case 2: // KEYSWITCHING_METHOD_II
 
                 if (scheme_ == scheme_type::bfv)
                 { // no leveled
@@ -142,7 +142,7 @@ namespace heongpu
                 }
 
                 break;
-            case 3: // KEYSWITHING_METHOD_III
+            case 3: // KEYSWITCHING_METHOD_III
 
                 if (scheme_ == scheme_type::bfv)
                 { // no leveled
@@ -190,14 +190,14 @@ namespace heongpu
 
         switch (static_cast<int>(context.keyswitching_type_))
         {
-            case 1: // KEYSWITHING_METHOD_I
+            case 1: // KEYSWITCHING_METHOD_I
             {
                 throw std::invalid_argument("Invalid Key Size");
             }
-            case 2: // KEYSWITHING_METHOD_II
+            case 2: // KEYSWITCHING_METHOD_II
                 throw std::invalid_argument("Invalid Key Size");
                 break;
-            case 3: // KEYSWITHING_METHOD_III
+            case 3: // KEYSWITCHING_METHOD_III
 
                 if (scheme_ == scheme_type::bfv)
                 { // no leveled
@@ -249,7 +249,7 @@ namespace heongpu
         }
         else
         {
-            if ((key_type == keyswitching_type::KEYSWITHING_METHOD_III) &&
+            if ((key_type == keyswitching_type::KEYSWITCHING_METHOD_III) &&
                 scheme_ == scheme_type::ckks)
             {
                 int max_depth = Q_size_ - 1;
@@ -278,7 +278,7 @@ namespace heongpu
     {
         if (store_in_gpu_)
         {
-            if ((key_type == keyswitching_type::KEYSWITHING_METHOD_III) &&
+            if ((key_type == keyswitching_type::KEYSWITCHING_METHOD_III) &&
                 scheme_ == scheme_type::ckks)
             {
                 int max_depth = Q_size_ - 1;
@@ -360,7 +360,7 @@ namespace heongpu
 
         switch (static_cast<int>(context.keyswitching_type_))
         {
-            case 1: // KEYSWITHING_METHOD_I
+            case 1: // KEYSWITCHING_METHOD_I
             {
                 galoiskey_size_ = 2 * Q_size_ * Q_prime_size_ * ring_size;
 
@@ -376,7 +376,7 @@ namespace heongpu
 
                 break;
             }
-            case 2: // KEYSWITHING_METHOD_II
+            case 2: // KEYSWITCHING_METHOD_II
             {
                 for (int i = 0; i < MAX_SHIFT; i++)
                 {
@@ -407,9 +407,9 @@ namespace heongpu
 
                 break;
             }
-            case 3: // KEYSWITHING_METHOD_III Galoiskey
+            case 3: // KEYSWITCHING_METHOD_III Galoiskey
                 throw std::invalid_argument(
-                    "Galoiskey does not support KEYSWITHING_METHOD_III");
+                    "Galoiskey does not support KEYSWITCHING_METHOD_III");
                 break;
             default:
                 throw std::invalid_argument("Invalid Key Switching Type");
@@ -437,7 +437,7 @@ namespace heongpu
 
         switch (static_cast<int>(context.keyswitching_type_))
         {
-            case 1: // KEYSWITHING_METHOD_I
+            case 1: // KEYSWITCHING_METHOD_I
             {
                 galoiskey_size_ = 2 * Q_size_ * Q_prime_size_ * ring_size;
 
@@ -450,7 +450,7 @@ namespace heongpu
 
                 break;
             }
-            case 2: // KEYSWITHING_METHOD_II
+            case 2: // KEYSWITCHING_METHOD_II
             {
                 for (int shift : shift_vec)
                 {
@@ -478,9 +478,9 @@ namespace heongpu
 
                 break;
             }
-            case 3: // KEYSWITHING_METHOD_III Galoiskey
+            case 3: // KEYSWITCHING_METHOD_III Galoiskey
                 throw std::invalid_argument(
-                    "Galoiskey does not support KEYSWITHING_METHOD_III");
+                    "Galoiskey does not support KEYSWITCHING_METHOD_III");
                 break;
             default:
                 throw std::invalid_argument("Invalid Key Switching Type");
@@ -507,7 +507,7 @@ namespace heongpu
 
         switch (static_cast<int>(context.keyswitching_type_))
         {
-            case 1: // KEYSWITHING_METHOD_I
+            case 1: // KEYSWITCHING_METHOD_I
             {
                 galois_elt_zero = steps_to_galois_elt(0, ring_size);
                 galoiskey_size_ = 2 * Q_size_ * Q_prime_size_ * ring_size;
@@ -515,7 +515,7 @@ namespace heongpu
 
                 break;
             }
-            case 2: // KEYSWITHING_METHOD_II
+            case 2: // KEYSWITCHING_METHOD_II
 
                 if (scheme_ == scheme_type::bfv)
                 { // no leveled
@@ -538,9 +538,9 @@ namespace heongpu
                 }
 
                 break;
-            case 3: // KEYSWITHING_METHOD_III Galoiskey
+            case 3: // KEYSWITCHING_METHOD_III Galoiskey
                 throw std::invalid_argument(
-                    "Galoiskey does not support KEYSWITHING_METHOD_III");
+                    "Galoiskey does not support KEYSWITCHING_METHOD_III");
                 break;
             default:
                 throw std::invalid_argument("Invalid Key Switching Type");
@@ -645,12 +645,12 @@ namespace heongpu
 
         switch (static_cast<int>(context.keyswitching_type_))
         {
-            case 1: // KEYSWITHING_METHOD_I
+            case 1: // KEYSWITCHING_METHOD_I
 
                 // It can use for both leveled and no leveled.
                 switchkey_size_ = 2 * Q_size_ * Q_prime_size_ * ring_size;
                 break;
-            case 2: // KEYSWITHING_METHOD_II
+            case 2: // KEYSWITCHING_METHOD_II
 
                 if (scheme_ == scheme_type::bfv)
                 { // no leveled
@@ -670,9 +670,9 @@ namespace heongpu
                 }
 
                 break;
-            case 3: // KEYSWITHING_METHOD_III Galoiskey
+            case 3: // KEYSWITCHING_METHOD_III Galoiskey
                 throw std::invalid_argument(
-                    "Switchkey does not support KEYSWITHING_METHOD_III");
+                    "Switchkey does not support KEYSWITCHING_METHOD_III");
                 break;
             default:
                 throw std::invalid_argument("Invalid Key Switching Type");

--- a/src/heongpu/lib/host/operator.cu
+++ b/src/heongpu/lib/host/operator.cu
@@ -165,7 +165,7 @@ namespace heongpu
             temp2_mul = temp1_mul + (4 * n * (bsk_mod_count_ + Q_size_));
 
             if (context.keyswitching_type_ ==
-                keyswitching_type::KEYSWITHING_METHOD_I)
+                keyswitching_type::KEYSWITCHING_METHOD_I)
             {
                 temp_relin = DeviceVector<Data>((n * Q_size_ * Q_prime_size_) +
                                                 (2 * n * Q_prime_size_));
@@ -180,7 +180,7 @@ namespace heongpu
                 temp2_rotation = temp1_rotation + (n * Q_size_ * Q_prime_size_);
             }
             else if (context.keyswitching_type_ ==
-                     keyswitching_type::KEYSWITHING_METHOD_II)
+                     keyswitching_type::KEYSWITCHING_METHOD_II)
             {
                 temp_relin = DeviceVector<Data>((n * Q_size_ * Q_prime_size_) +
                                                 (2 * n * Q_prime_size_));
@@ -197,7 +197,7 @@ namespace heongpu
                 temp3_rotation = temp2_rotation + (2 * n * Q_prime_size_ * d);
             }
             else if (context.keyswitching_type_ ==
-                     keyswitching_type::KEYSWITHING_METHOD_III)
+                     keyswitching_type::KEYSWITCHING_METHOD_III)
             {
                 temp_relin_new = DeviceVector<Data>(
                     (n * d * r_prime) + (2 * n * d_tilda * r_prime) +
@@ -221,7 +221,7 @@ namespace heongpu
         else if (scheme_ == scheme_type::ckks)
         {
             if (context.keyswitching_type_ ==
-                keyswitching_type::KEYSWITHING_METHOD_I)
+                keyswitching_type::KEYSWITCHING_METHOD_I)
             {
                 temp_relin = DeviceVector<Data>((n * Q_size_ * Q_prime_size_) +
                                                 (2 * n * Q_prime_size_));
@@ -238,7 +238,7 @@ namespace heongpu
                 temp3_rotation = temp2_rotation + (n * Q_size_ * Q_prime_size_);
             }
             else if (context.keyswitching_type_ ==
-                     keyswitching_type::KEYSWITHING_METHOD_II)
+                     keyswitching_type::KEYSWITCHING_METHOD_II)
             {
                 temp_relin = DeviceVector<Data>((n * Q_size_ * Q_prime_size_) +
                                                 (2 * n * Q_prime_size_));
@@ -259,7 +259,7 @@ namespace heongpu
                     (2 * n * d_leveled_->operator[](0) * Q_prime_size_);
             }
             else if (context.keyswitching_type_ ==
-                     keyswitching_type::KEYSWITHING_METHOD_III)
+                     keyswitching_type::KEYSWITCHING_METHOD_III)
             {
                 temp_relin_new = DeviceVector<Data>(
                     (n * d_leveled_->operator[](0) * r_prime_leveled_) +

--- a/src/heongpu/lib/kernel/context.cu
+++ b/src/heongpu/lib/kernel/context.cu
@@ -745,10 +745,11 @@ namespace heongpu
         if (!context_generated)
         {
             if ((log_P_bases_bit_sizes.size() > 1) &&
-                (keyswitching_type_ == keyswitching_type::KEYSWITHING_METHOD_I))
+                (keyswitching_type_ ==
+                 keyswitching_type::KEYSWITCHING_METHOD_I))
             {
                 throw std::logic_error("log_P_bases_bit_sizes cannot be higher "
-                                       "than 1 for KEYSWITHING_METHOD_I!");
+                                       "than 1 for KEYSWITCHING_METHOD_I!");
             }
 
             if (!check_coeffs(log_Q_bases_bit_sizes, log_P_bases_bit_sizes))
@@ -839,10 +840,11 @@ namespace heongpu
         if (!context_generated)
         {
             if ((P_modulus_size > 1) &&
-                (keyswitching_type_ == keyswitching_type::KEYSWITHING_METHOD_I))
+                (keyswitching_type_ ==
+                 keyswitching_type::KEYSWITCHING_METHOD_I))
             {
                 throw std::logic_error("log_P_bases_bit_sizes cannot be higher "
-                                       "than 1 for KEYSWITHING_METHOD_I!");
+                                       "than 1 for KEYSWITCHING_METHOD_I!");
             }
 
             total_coeff_bit_count = 0;
@@ -1332,10 +1334,10 @@ namespace heongpu
 
         switch (static_cast<int>(keyswitching_type_))
         {
-            case 1: // KEYSWITHING_METHOD_I
+            case 1: // KEYSWITCHING_METHOD_I
                 // Deafult
                 break;
-            case 2: // KEYSWITHING_METHOD_II
+            case 2: // KEYSWITCHING_METHOD_II
 
                 if (scheme_ == scheme_type::bfv)
                 {
@@ -1459,7 +1461,7 @@ namespace heongpu
                     throw std::invalid_argument("Invalid Key Switching Type");
                 }
                 break;
-            case 3: // KEYSWITHING_METHOD_III
+            case 3: // KEYSWITCHING_METHOD_III
 
                 if (scheme_ == scheme_type::bfv)
                 {
@@ -1710,7 +1712,7 @@ namespace heongpu
             temp2_mul = temp1_mul + (4 * n * (bsk_modulus_count_ + Q_size_));
 
             if (context.keyswitching_type_ ==
-                keyswitching_type::KEYSWITHING_METHOD_I)
+                keyswitching_type::KEYSWITCHING_METHOD_I)
             {
                 temp_relin = DeviceVector<Data>((n * Q_size_ * Q_prime_size_) +
                                                 (2 * n * Q_prime_size_));
@@ -1725,7 +1727,7 @@ namespace heongpu
                 temp2_rotation = temp1_rotation + (n * Q_size_ * Q_prime_size_);
             }
             else if (context.keyswitching_type_ ==
-                     keyswitching_type::KEYSWITHING_METHOD_II)
+                     keyswitching_type::KEYSWITCHING_METHOD_II)
             {
                 temp_relin = DeviceVector<Data>((n * Q_size_ * Q_prime_size_) +
                                                 (2 * n * Q_prime_size_));
@@ -1742,7 +1744,7 @@ namespace heongpu
                 temp3_rotation = temp2_rotation + (2 * n * Q_prime_size_ * d);
             }
             else if (context.keyswitching_type_ ==
-                     keyswitching_type::KEYSWITHING_METHOD_III)
+                     keyswitching_type::KEYSWITCHING_METHOD_III)
             {
                 temp_relin_new = DeviceVector<Data>(
                     (n * d * r_prime) + (2 * n * d_tilda * r_prime) +
@@ -1766,7 +1768,7 @@ namespace heongpu
         else if (scheme == scheme_type::ckks)
         {
             if (context.keyswitching_type_ ==
-                keyswitching_type::KEYSWITHING_METHOD_I)
+                keyswitching_type::KEYSWITCHING_METHOD_I)
             {
                 temp_relin = DeviceVector<Data>((n * Q_size_ * Q_prime_size_) +
                                                 (2 * n * Q_prime_size_));
@@ -1783,7 +1785,7 @@ namespace heongpu
                 temp3_rotation = temp2_rotation + (n * Q_size_ * Q_prime_size_);
             }
             else if (context.keyswitching_type_ ==
-                     keyswitching_type::KEYSWITHING_METHOD_II)
+                     keyswitching_type::KEYSWITCHING_METHOD_II)
             {
                 temp_relin = DeviceVector<Data>((n * Q_size_ * Q_prime_size_) +
                                                 (2 * n * Q_prime_size_));
@@ -1804,7 +1806,7 @@ namespace heongpu
                     (2 * n * d_leveled_->operator[](0) * Q_prime_size_);
             }
             else if (context.keyswitching_type_ ==
-                     keyswitching_type::KEYSWITHING_METHOD_III)
+                     keyswitching_type::KEYSWITCHING_METHOD_III)
             {
                 temp_relin_new = DeviceVector<Data>(
                     (n * d_leveled_->operator[](0) * r_prime_leveled_) +

--- a/test/test_bfv_addition.cu
+++ b/test/test_bfv_addition.cu
@@ -14,7 +14,7 @@ TEST(HEonGPU, BFV_Ciphertext_Ciphertext_Addition_Subtraction)
         int plain_modulus = 1032193;
         heongpu::Parameters context(
             heongpu::scheme_type::bfv,
-            heongpu::keyswitching_type::KEYSWITHING_METHOD_I,
+            heongpu::keyswitching_type::KEYSWITCHING_METHOD_I,
             heongpu::sec_level_type::none);
         context.set_poly_modulus_degree(poly_modulus_degree);
         context.set_coeff_modulus({36, 36}, {37});
@@ -109,7 +109,7 @@ TEST(HEonGPU, BFV_Ciphertext_Ciphertext_Addition_Subtraction)
         int plain_modulus = 1032193;
         heongpu::Parameters context(
             heongpu::scheme_type::bfv,
-            heongpu::keyswitching_type::KEYSWITHING_METHOD_I,
+            heongpu::keyswitching_type::KEYSWITCHING_METHOD_I,
             heongpu::sec_level_type::none);
         context.set_poly_modulus_degree(poly_modulus_degree);
         context.set_coeff_modulus({54, 54, 54}, {55});
@@ -204,7 +204,7 @@ TEST(HEonGPU, BFV_Ciphertext_Ciphertext_Addition_Subtraction)
         int plain_modulus = 786433;
         heongpu::Parameters context(
             heongpu::scheme_type::bfv,
-            heongpu::keyswitching_type::KEYSWITHING_METHOD_I,
+            heongpu::keyswitching_type::KEYSWITCHING_METHOD_I,
             heongpu::sec_level_type::none);
         context.set_poly_modulus_degree(poly_modulus_degree);
         context.set_coeff_modulus({54, 54, 54, 54, 55, 55, 55}, {55});
@@ -299,7 +299,7 @@ TEST(HEonGPU, BFV_Ciphertext_Ciphertext_Addition_Subtraction)
         int plain_modulus = 786433;
         heongpu::Parameters context(
             heongpu::scheme_type::bfv,
-            heongpu::keyswitching_type::KEYSWITHING_METHOD_I,
+            heongpu::keyswitching_type::KEYSWITCHING_METHOD_I,
             heongpu::sec_level_type::none);
         context.set_poly_modulus_degree(poly_modulus_degree);
         context.set_coeff_modulus(
@@ -395,7 +395,7 @@ TEST(HEonGPU, BFV_Ciphertext_Ciphertext_Addition_Subtraction)
         int plain_modulus = 786433;
         heongpu::Parameters context(
             heongpu::scheme_type::bfv,
-            heongpu::keyswitching_type::KEYSWITHING_METHOD_I,
+            heongpu::keyswitching_type::KEYSWITCHING_METHOD_I,
             heongpu::sec_level_type::none);
         context.set_poly_modulus_degree(poly_modulus_degree);
         context.set_coeff_modulus({58, 58, 58, 58, 58, 58, 58, 58, 58, 59,

--- a/test/test_bfv_encoding.cu
+++ b/test/test_bfv_encoding.cu
@@ -14,7 +14,7 @@ TEST(HEonGPU, BFV_Encoding_Decoding)
         int plain_modulus = 1032193;
         heongpu::Parameters context(
             heongpu::scheme_type::bfv,
-            heongpu::keyswitching_type::KEYSWITHING_METHOD_I,
+            heongpu::keyswitching_type::KEYSWITCHING_METHOD_I,
             heongpu::sec_level_type::none);
         context.set_poly_modulus_degree(poly_modulus_degree);
         context.set_coeff_modulus({36, 36}, {37});
@@ -50,7 +50,7 @@ TEST(HEonGPU, BFV_Encoding_Decoding)
         int plain_modulus = 1032193;
         heongpu::Parameters context(
             heongpu::scheme_type::bfv,
-            heongpu::keyswitching_type::KEYSWITHING_METHOD_I,
+            heongpu::keyswitching_type::KEYSWITCHING_METHOD_I,
             heongpu::sec_level_type::none);
         context.set_poly_modulus_degree(poly_modulus_degree);
         context.set_coeff_modulus({54, 54, 54}, {55});
@@ -86,7 +86,7 @@ TEST(HEonGPU, BFV_Encoding_Decoding)
         int plain_modulus = 786433;
         heongpu::Parameters context(
             heongpu::scheme_type::bfv,
-            heongpu::keyswitching_type::KEYSWITHING_METHOD_I,
+            heongpu::keyswitching_type::KEYSWITCHING_METHOD_I,
             heongpu::sec_level_type::none);
         context.set_poly_modulus_degree(poly_modulus_degree);
         context.set_coeff_modulus({54, 54, 54, 54, 55, 55, 55}, {55});
@@ -122,7 +122,7 @@ TEST(HEonGPU, BFV_Encoding_Decoding)
         int plain_modulus = 786433;
         heongpu::Parameters context(
             heongpu::scheme_type::bfv,
-            heongpu::keyswitching_type::KEYSWITHING_METHOD_I,
+            heongpu::keyswitching_type::KEYSWITCHING_METHOD_I,
             heongpu::sec_level_type::none);
         context.set_poly_modulus_degree(poly_modulus_degree);
         context.set_coeff_modulus(
@@ -159,7 +159,7 @@ TEST(HEonGPU, BFV_Encoding_Decoding)
         int plain_modulus = 786433;
         heongpu::Parameters context(
             heongpu::scheme_type::bfv,
-            heongpu::keyswitching_type::KEYSWITHING_METHOD_I,
+            heongpu::keyswitching_type::KEYSWITCHING_METHOD_I,
             heongpu::sec_level_type::none);
         context.set_poly_modulus_degree(poly_modulus_degree);
         context.set_coeff_modulus({58, 58, 58, 58, 58, 58, 58, 58, 58, 59,

--- a/test/test_bfv_encryption.cu
+++ b/test/test_bfv_encryption.cu
@@ -14,7 +14,7 @@ TEST(HEonGPU, BFV_Encryption_Decryption)
         int plain_modulus = 1032193;
         heongpu::Parameters context(
             heongpu::scheme_type::bfv,
-            heongpu::keyswitching_type::KEYSWITHING_METHOD_I,
+            heongpu::keyswitching_type::KEYSWITCHING_METHOD_I,
             heongpu::sec_level_type::none);
         context.set_poly_modulus_degree(poly_modulus_degree);
         context.set_coeff_modulus({36, 36}, {37});
@@ -65,7 +65,7 @@ TEST(HEonGPU, BFV_Encryption_Decryption)
         int plain_modulus = 1032193;
         heongpu::Parameters context(
             heongpu::scheme_type::bfv,
-            heongpu::keyswitching_type::KEYSWITHING_METHOD_I,
+            heongpu::keyswitching_type::KEYSWITCHING_METHOD_I,
             heongpu::sec_level_type::none);
         context.set_poly_modulus_degree(poly_modulus_degree);
         context.set_coeff_modulus({54, 54, 54}, {55});
@@ -116,7 +116,7 @@ TEST(HEonGPU, BFV_Encryption_Decryption)
         int plain_modulus = 786433;
         heongpu::Parameters context(
             heongpu::scheme_type::bfv,
-            heongpu::keyswitching_type::KEYSWITHING_METHOD_I,
+            heongpu::keyswitching_type::KEYSWITCHING_METHOD_I,
             heongpu::sec_level_type::none);
         context.set_poly_modulus_degree(poly_modulus_degree);
         context.set_coeff_modulus({54, 54, 54, 54, 55, 55, 55}, {55});
@@ -167,7 +167,7 @@ TEST(HEonGPU, BFV_Encryption_Decryption)
         int plain_modulus = 786433;
         heongpu::Parameters context(
             heongpu::scheme_type::bfv,
-            heongpu::keyswitching_type::KEYSWITHING_METHOD_I,
+            heongpu::keyswitching_type::KEYSWITCHING_METHOD_I,
             heongpu::sec_level_type::none);
         context.set_poly_modulus_degree(poly_modulus_degree);
         context.set_coeff_modulus(
@@ -219,7 +219,7 @@ TEST(HEonGPU, BFV_Encryption_Decryption)
         int plain_modulus = 786433;
         heongpu::Parameters context(
             heongpu::scheme_type::bfv,
-            heongpu::keyswitching_type::KEYSWITHING_METHOD_I,
+            heongpu::keyswitching_type::KEYSWITCHING_METHOD_I,
             heongpu::sec_level_type::none);
         context.set_poly_modulus_degree(poly_modulus_degree);
         context.set_coeff_modulus({58, 58, 58, 58, 58, 58, 58, 58, 58, 59,

--- a/test/test_bfv_multiplication.cu
+++ b/test/test_bfv_multiplication.cu
@@ -14,7 +14,7 @@ TEST(HEonGPU, BFV_Ciphertext_Ciphertext_Multiplication_with_Relinearization)
         int plain_modulus = 1032193;
         heongpu::Parameters context(
             heongpu::scheme_type::bfv,
-            heongpu::keyswitching_type::KEYSWITHING_METHOD_I,
+            heongpu::keyswitching_type::KEYSWITCHING_METHOD_I,
             heongpu::sec_level_type::none);
         context.set_poly_modulus_degree(poly_modulus_degree);
         context.set_coeff_modulus({40, 40}, {40});
@@ -92,7 +92,7 @@ TEST(HEonGPU, BFV_Ciphertext_Ciphertext_Multiplication_with_Relinearization)
         int plain_modulus = 1032193;
         heongpu::Parameters context(
             heongpu::scheme_type::bfv,
-            heongpu::keyswitching_type::KEYSWITHING_METHOD_I,
+            heongpu::keyswitching_type::KEYSWITCHING_METHOD_I,
             heongpu::sec_level_type::none);
         context.set_poly_modulus_degree(poly_modulus_degree);
         context.set_coeff_modulus({54, 54, 54}, {55});
@@ -170,7 +170,7 @@ TEST(HEonGPU, BFV_Ciphertext_Ciphertext_Multiplication_with_Relinearization)
         int plain_modulus = 786433;
         heongpu::Parameters context(
             heongpu::scheme_type::bfv,
-            heongpu::keyswitching_type::KEYSWITHING_METHOD_I,
+            heongpu::keyswitching_type::KEYSWITCHING_METHOD_I,
             heongpu::sec_level_type::none);
         context.set_poly_modulus_degree(poly_modulus_degree);
         context.set_coeff_modulus({54, 54, 54, 54, 55, 55, 55}, {55});
@@ -248,7 +248,7 @@ TEST(HEonGPU, BFV_Ciphertext_Ciphertext_Multiplication_with_Relinearization)
         int plain_modulus = 786433;
         heongpu::Parameters context(
             heongpu::scheme_type::bfv,
-            heongpu::keyswitching_type::KEYSWITHING_METHOD_I,
+            heongpu::keyswitching_type::KEYSWITCHING_METHOD_I,
             heongpu::sec_level_type::none);
         context.set_poly_modulus_degree(poly_modulus_degree);
         context.set_coeff_modulus(
@@ -327,7 +327,7 @@ TEST(HEonGPU, BFV_Ciphertext_Ciphertext_Multiplication_with_Relinearization)
         int plain_modulus = 786433;
         heongpu::Parameters context(
             heongpu::scheme_type::bfv,
-            heongpu::keyswitching_type::KEYSWITHING_METHOD_I,
+            heongpu::keyswitching_type::KEYSWITCHING_METHOD_I,
             heongpu::sec_level_type::none);
         context.set_poly_modulus_degree(poly_modulus_degree);
         context.set_coeff_modulus({58, 58, 58, 58, 58, 58, 58, 58, 58, 59,
@@ -412,7 +412,7 @@ TEST(HEonGPU, BFV_Ciphertext_Plaintext_Multiplication)
         int plain_modulus = 1032193;
         heongpu::Parameters context(
             heongpu::scheme_type::bfv,
-            heongpu::keyswitching_type::KEYSWITHING_METHOD_I,
+            heongpu::keyswitching_type::KEYSWITCHING_METHOD_I,
             heongpu::sec_level_type::none);
         context.set_poly_modulus_degree(poly_modulus_degree);
         context.set_coeff_modulus({40, 40}, {40});
@@ -483,7 +483,7 @@ TEST(HEonGPU, BFV_Ciphertext_Plaintext_Multiplication)
         int plain_modulus = 1032193;
         heongpu::Parameters context(
             heongpu::scheme_type::bfv,
-            heongpu::keyswitching_type::KEYSWITHING_METHOD_I,
+            heongpu::keyswitching_type::KEYSWITCHING_METHOD_I,
             heongpu::sec_level_type::none);
         context.set_poly_modulus_degree(poly_modulus_degree);
         context.set_coeff_modulus({54, 54, 54}, {55});
@@ -554,7 +554,7 @@ TEST(HEonGPU, BFV_Ciphertext_Plaintext_Multiplication)
         int plain_modulus = 786433;
         heongpu::Parameters context(
             heongpu::scheme_type::bfv,
-            heongpu::keyswitching_type::KEYSWITHING_METHOD_I,
+            heongpu::keyswitching_type::KEYSWITCHING_METHOD_I,
             heongpu::sec_level_type::none);
         context.set_poly_modulus_degree(poly_modulus_degree);
         context.set_coeff_modulus({54, 54, 54, 54, 55, 55, 55}, {55});
@@ -625,7 +625,7 @@ TEST(HEonGPU, BFV_Ciphertext_Plaintext_Multiplication)
         int plain_modulus = 786433;
         heongpu::Parameters context(
             heongpu::scheme_type::bfv,
-            heongpu::keyswitching_type::KEYSWITHING_METHOD_I,
+            heongpu::keyswitching_type::KEYSWITCHING_METHOD_I,
             heongpu::sec_level_type::none);
         context.set_poly_modulus_degree(poly_modulus_degree);
         context.set_coeff_modulus(
@@ -700,7 +700,7 @@ TEST(HEonGPU, BFV_Ciphertext_Plaintext_Multiplication)
         int plain_modulus = 786433;
         heongpu::Parameters context(
             heongpu::scheme_type::bfv,
-            heongpu::keyswitching_type::KEYSWITHING_METHOD_I,
+            heongpu::keyswitching_type::KEYSWITCHING_METHOD_I,
             heongpu::sec_level_type::none);
         context.set_poly_modulus_degree(poly_modulus_degree);
         context.set_coeff_modulus({58, 58, 58, 58, 58, 58, 58, 58, 58, 59,

--- a/test/test_bfv_relinearization.cu
+++ b/test/test_bfv_relinearization.cu
@@ -14,7 +14,7 @@ TEST(HEonGPU, BFV_Relinearization_Keyswitching_Method_I)
         int plain_modulus = 1032193;
         heongpu::Parameters context(
             heongpu::scheme_type::bfv,
-            heongpu::keyswitching_type::KEYSWITHING_METHOD_I,
+            heongpu::keyswitching_type::KEYSWITCHING_METHOD_I,
             heongpu::sec_level_type::none);
         context.set_poly_modulus_degree(poly_modulus_degree);
         context.set_coeff_modulus({40, 40}, {40});
@@ -92,7 +92,7 @@ TEST(HEonGPU, BFV_Relinearization_Keyswitching_Method_I)
         int plain_modulus = 1032193;
         heongpu::Parameters context(
             heongpu::scheme_type::bfv,
-            heongpu::keyswitching_type::KEYSWITHING_METHOD_I,
+            heongpu::keyswitching_type::KEYSWITCHING_METHOD_I,
             heongpu::sec_level_type::none);
         context.set_poly_modulus_degree(poly_modulus_degree);
         context.set_coeff_modulus({54, 54, 54}, {55});
@@ -170,7 +170,7 @@ TEST(HEonGPU, BFV_Relinearization_Keyswitching_Method_I)
         int plain_modulus = 786433;
         heongpu::Parameters context(
             heongpu::scheme_type::bfv,
-            heongpu::keyswitching_type::KEYSWITHING_METHOD_I,
+            heongpu::keyswitching_type::KEYSWITCHING_METHOD_I,
             heongpu::sec_level_type::none);
         context.set_poly_modulus_degree(poly_modulus_degree);
         context.set_coeff_modulus({54, 54, 54, 54, 55, 55, 55}, {55});
@@ -248,7 +248,7 @@ TEST(HEonGPU, BFV_Relinearization_Keyswitching_Method_I)
         int plain_modulus = 786433;
         heongpu::Parameters context(
             heongpu::scheme_type::bfv,
-            heongpu::keyswitching_type::KEYSWITHING_METHOD_I,
+            heongpu::keyswitching_type::KEYSWITCHING_METHOD_I,
             heongpu::sec_level_type::none);
         context.set_poly_modulus_degree(poly_modulus_degree);
         context.set_coeff_modulus(
@@ -327,7 +327,7 @@ TEST(HEonGPU, BFV_Relinearization_Keyswitching_Method_I)
         int plain_modulus = 786433;
         heongpu::Parameters context(
             heongpu::scheme_type::bfv,
-            heongpu::keyswitching_type::KEYSWITHING_METHOD_I,
+            heongpu::keyswitching_type::KEYSWITCHING_METHOD_I,
             heongpu::sec_level_type::none);
         context.set_poly_modulus_degree(poly_modulus_degree);
         context.set_coeff_modulus({58, 58, 58, 58, 58, 58, 58, 58, 58, 59,
@@ -412,7 +412,7 @@ TEST(HEonGPU, BFV_Relinearization_Keyswitching_Method_II)
         int plain_modulus = 1032193;
         heongpu::Parameters context(
             heongpu::scheme_type::bfv,
-            heongpu::keyswitching_type::KEYSWITHING_METHOD_II,
+            heongpu::keyswitching_type::KEYSWITCHING_METHOD_II,
             heongpu::sec_level_type::none);
         context.set_poly_modulus_degree(poly_modulus_degree);
         context.set_coeff_modulus({40, 40}, {40, 40});
@@ -490,7 +490,7 @@ TEST(HEonGPU, BFV_Relinearization_Keyswitching_Method_II)
         int plain_modulus = 1032193;
         heongpu::Parameters context(
             heongpu::scheme_type::bfv,
-            heongpu::keyswitching_type::KEYSWITHING_METHOD_II,
+            heongpu::keyswitching_type::KEYSWITCHING_METHOD_II,
             heongpu::sec_level_type::none);
         context.set_poly_modulus_degree(poly_modulus_degree);
         context.set_coeff_modulus({54, 54, 54}, {55, 55});
@@ -568,7 +568,7 @@ TEST(HEonGPU, BFV_Relinearization_Keyswitching_Method_II)
         int plain_modulus = 786433;
         heongpu::Parameters context(
             heongpu::scheme_type::bfv,
-            heongpu::keyswitching_type::KEYSWITHING_METHOD_II,
+            heongpu::keyswitching_type::KEYSWITCHING_METHOD_II,
             heongpu::sec_level_type::none);
         context.set_poly_modulus_degree(poly_modulus_degree);
         context.set_coeff_modulus({54, 54, 54, 54, 55, 55, 55}, {55, 55});
@@ -646,7 +646,7 @@ TEST(HEonGPU, BFV_Relinearization_Keyswitching_Method_II)
         int plain_modulus = 786433;
         heongpu::Parameters context(
             heongpu::scheme_type::bfv,
-            heongpu::keyswitching_type::KEYSWITHING_METHOD_II,
+            heongpu::keyswitching_type::KEYSWITCHING_METHOD_II,
             heongpu::sec_level_type::none);
         context.set_poly_modulus_degree(poly_modulus_degree);
         context.set_coeff_modulus(
@@ -725,7 +725,7 @@ TEST(HEonGPU, BFV_Relinearization_Keyswitching_Method_II)
         int plain_modulus = 786433;
         heongpu::Parameters context(
             heongpu::scheme_type::bfv,
-            heongpu::keyswitching_type::KEYSWITHING_METHOD_II,
+            heongpu::keyswitching_type::KEYSWITCHING_METHOD_II,
             heongpu::sec_level_type::none);
         context.set_poly_modulus_degree(poly_modulus_degree);
         context.set_coeff_modulus({58, 58, 58, 58, 58, 58, 58, 58, 58, 59,
@@ -810,7 +810,7 @@ TEST(HEonGPU, BFV_Relinearization_Keyswitching_Method_III)
         int plain_modulus = 1032193;
         heongpu::Parameters context(
             heongpu::scheme_type::bfv,
-            heongpu::keyswitching_type::KEYSWITHING_METHOD_III,
+            heongpu::keyswitching_type::KEYSWITCHING_METHOD_III,
             heongpu::sec_level_type::none);
         context.set_poly_modulus_degree(poly_modulus_degree);
         context.set_coeff_modulus({40, 40}, {40, 40});
@@ -888,7 +888,7 @@ TEST(HEonGPU, BFV_Relinearization_Keyswitching_Method_III)
         int plain_modulus = 1032193;
         heongpu::Parameters context(
             heongpu::scheme_type::bfv,
-            heongpu::keyswitching_type::KEYSWITHING_METHOD_III,
+            heongpu::keyswitching_type::KEYSWITCHING_METHOD_III,
             heongpu::sec_level_type::none);
         context.set_poly_modulus_degree(poly_modulus_degree);
         context.set_coeff_modulus({54, 54, 54}, {55, 55});
@@ -966,7 +966,7 @@ TEST(HEonGPU, BFV_Relinearization_Keyswitching_Method_III)
         int plain_modulus = 786433;
         heongpu::Parameters context(
             heongpu::scheme_type::bfv,
-            heongpu::keyswitching_type::KEYSWITHING_METHOD_III,
+            heongpu::keyswitching_type::KEYSWITCHING_METHOD_III,
             heongpu::sec_level_type::none);
         context.set_poly_modulus_degree(poly_modulus_degree);
         context.set_coeff_modulus({54, 54, 54, 54, 55, 55, 55}, {55, 55});
@@ -1044,7 +1044,7 @@ TEST(HEonGPU, BFV_Relinearization_Keyswitching_Method_III)
         int plain_modulus = 786433;
         heongpu::Parameters context(
             heongpu::scheme_type::bfv,
-            heongpu::keyswitching_type::KEYSWITHING_METHOD_III,
+            heongpu::keyswitching_type::KEYSWITCHING_METHOD_III,
             heongpu::sec_level_type::none);
         context.set_poly_modulus_degree(poly_modulus_degree);
         context.set_coeff_modulus(
@@ -1123,7 +1123,7 @@ TEST(HEonGPU, BFV_Relinearization_Keyswitching_Method_III)
         int plain_modulus = 786433;
         heongpu::Parameters context(
             heongpu::scheme_type::bfv,
-            heongpu::keyswitching_type::KEYSWITHING_METHOD_III,
+            heongpu::keyswitching_type::KEYSWITCHING_METHOD_III,
             heongpu::sec_level_type::none);
         context.set_poly_modulus_degree(poly_modulus_degree);
         context.set_coeff_modulus({58, 58, 58, 58, 58, 58, 58, 58, 58, 59,

--- a/test/test_bfv_rotation_method_1.cu
+++ b/test/test_bfv_rotation_method_1.cu
@@ -15,7 +15,7 @@ TEST(HEonGPU, BFV_Ciphertext_Rotation_Keyswitching_Method_I)
         int plain_modulus = 1032193;
         heongpu::Parameters context(
             heongpu::scheme_type::bfv,
-            heongpu::keyswitching_type::KEYSWITHING_METHOD_I,
+            heongpu::keyswitching_type::KEYSWITCHING_METHOD_I,
             heongpu::sec_level_type::none);
         context.set_poly_modulus_degree(poly_modulus_degree);
         context.set_coeff_modulus({40, 40}, {40});
@@ -84,7 +84,7 @@ TEST(HEonGPU, BFV_Ciphertext_Rotation_Keyswitching_Method_I)
         int plain_modulus = 1032193;
         heongpu::Parameters context(
             heongpu::scheme_type::bfv,
-            heongpu::keyswitching_type::KEYSWITHING_METHOD_I,
+            heongpu::keyswitching_type::KEYSWITCHING_METHOD_I,
             heongpu::sec_level_type::none);
         context.set_poly_modulus_degree(poly_modulus_degree);
         context.set_coeff_modulus({54, 54, 54}, {55});
@@ -153,7 +153,7 @@ TEST(HEonGPU, BFV_Ciphertext_Rotation_Keyswitching_Method_I)
         int plain_modulus = 786433;
         heongpu::Parameters context(
             heongpu::scheme_type::bfv,
-            heongpu::keyswitching_type::KEYSWITHING_METHOD_I,
+            heongpu::keyswitching_type::KEYSWITCHING_METHOD_I,
             heongpu::sec_level_type::none);
         context.set_poly_modulus_degree(poly_modulus_degree);
         context.set_coeff_modulus({54, 54, 54, 54, 55, 55, 55}, {55});
@@ -222,7 +222,7 @@ TEST(HEonGPU, BFV_Ciphertext_Rotation_Keyswitching_Method_I)
         int plain_modulus = 786433;
         heongpu::Parameters context(
             heongpu::scheme_type::bfv,
-            heongpu::keyswitching_type::KEYSWITHING_METHOD_I,
+            heongpu::keyswitching_type::KEYSWITCHING_METHOD_I,
             heongpu::sec_level_type::none);
         context.set_poly_modulus_degree(poly_modulus_degree);
         context.set_coeff_modulus(
@@ -293,7 +293,7 @@ TEST(HEonGPU, BFV_Ciphertext_Rotation_Keyswitching_Method_I)
         // TODO: find optimal way to store huge galois key, maybe store it in
         // CPU RAM.
         // heongpu::Parameters context(heongpu::scheme_type::bfv,
-        // heongpu::keyswitching_type::KEYSWITHING_METHOD_I,
+        // heongpu::keyswitching_type::KEYSWITCHING_METHOD_I,
         // heongpu::sec_level_type::none);
         // context.set_poly_modulus_degree(poly_modulus_degree);
         // context.set_coeff_modulus({58, 58, 58, 58, 58, 58, 58, 58, 58, 59,
@@ -304,7 +304,7 @@ TEST(HEonGPU, BFV_Ciphertext_Rotation_Keyswitching_Method_I)
         // context.generate();
         heongpu::Parameters context(
             heongpu::scheme_type::bfv,
-            heongpu::keyswitching_type::KEYSWITHING_METHOD_I,
+            heongpu::keyswitching_type::KEYSWITCHING_METHOD_I,
             heongpu::sec_level_type::none);
         context.set_poly_modulus_degree(poly_modulus_degree);
         context.set_coeff_modulus(

--- a/test/test_bfv_rotation_method_2.cu
+++ b/test/test_bfv_rotation_method_2.cu
@@ -15,7 +15,7 @@ TEST(HEonGPU, BFV_Ciphertext_Rotation_Keyswitching_Method_II)
         int plain_modulus = 1032193;
         heongpu::Parameters context(
             heongpu::scheme_type::bfv,
-            heongpu::keyswitching_type::KEYSWITHING_METHOD_II,
+            heongpu::keyswitching_type::KEYSWITCHING_METHOD_II,
             heongpu::sec_level_type::none);
         context.set_poly_modulus_degree(poly_modulus_degree);
         context.set_coeff_modulus({40, 40}, {40, 40});
@@ -84,7 +84,7 @@ TEST(HEonGPU, BFV_Ciphertext_Rotation_Keyswitching_Method_II)
         int plain_modulus = 1032193;
         heongpu::Parameters context(
             heongpu::scheme_type::bfv,
-            heongpu::keyswitching_type::KEYSWITHING_METHOD_II,
+            heongpu::keyswitching_type::KEYSWITCHING_METHOD_II,
             heongpu::sec_level_type::none);
         context.set_poly_modulus_degree(poly_modulus_degree);
         context.set_coeff_modulus({54, 54, 54}, {55, 55});
@@ -153,7 +153,7 @@ TEST(HEonGPU, BFV_Ciphertext_Rotation_Keyswitching_Method_II)
         int plain_modulus = 786433;
         heongpu::Parameters context(
             heongpu::scheme_type::bfv,
-            heongpu::keyswitching_type::KEYSWITHING_METHOD_II,
+            heongpu::keyswitching_type::KEYSWITCHING_METHOD_II,
             heongpu::sec_level_type::none);
         context.set_poly_modulus_degree(poly_modulus_degree);
         context.set_coeff_modulus({54, 54, 54, 54, 55, 55, 55}, {55, 55});
@@ -222,7 +222,7 @@ TEST(HEonGPU, BFV_Ciphertext_Rotation_Keyswitching_Method_II)
         int plain_modulus = 786433;
         heongpu::Parameters context(
             heongpu::scheme_type::bfv,
-            heongpu::keyswitching_type::KEYSWITHING_METHOD_II,
+            heongpu::keyswitching_type::KEYSWITCHING_METHOD_II,
             heongpu::sec_level_type::none);
         context.set_poly_modulus_degree(poly_modulus_degree);
         context.set_coeff_modulus(
@@ -293,7 +293,7 @@ TEST(HEonGPU, BFV_Ciphertext_Rotation_Keyswitching_Method_II)
         // TODO: find optimal way to store huge galois key, maybe store it in
         // CPU RAM.
         // heongpu::Parameters context(heongpu::scheme_type::bfv,
-        // heongpu::keyswitching_type::KEYSWITHING_METHOD_I,
+        // heongpu::keyswitching_type::KEYSWITCHING_METHOD_I,
         // heongpu::sec_level_type::none);
         // context.set_poly_modulus_degree(poly_modulus_degree);
         // context.set_coeff_modulus({58, 58, 58, 58, 58, 58, 58, 58, 58, 59,
@@ -304,7 +304,7 @@ TEST(HEonGPU, BFV_Ciphertext_Rotation_Keyswitching_Method_II)
         // context.generate();
         heongpu::Parameters context(
             heongpu::scheme_type::bfv,
-            heongpu::keyswitching_type::KEYSWITHING_METHOD_II,
+            heongpu::keyswitching_type::KEYSWITCHING_METHOD_II,
             heongpu::sec_level_type::none);
         context.set_poly_modulus_degree(poly_modulus_degree);
         context.set_coeff_modulus(

--- a/test/test_ckks_addition.cu
+++ b/test/test_ckks_addition.cu
@@ -40,7 +40,7 @@ TEST(HEonGPU, CKKS_Ciphertext_Ciphertext_Addition)
         size_t poly_modulus_degree = 4096;
         heongpu::Parameters context(
             heongpu::scheme_type::ckks,
-            heongpu::keyswitching_type::KEYSWITHING_METHOD_I,
+            heongpu::keyswitching_type::KEYSWITCHING_METHOD_I,
             heongpu::sec_level_type::none);
         context.set_poly_modulus_degree(poly_modulus_degree);
         context.set_coeff_modulus({40, 30, 30}, {40});
@@ -111,7 +111,7 @@ TEST(HEonGPU, CKKS_Ciphertext_Ciphertext_Addition)
         size_t poly_modulus_degree = 8192;
         heongpu::Parameters context(
             heongpu::scheme_type::ckks,
-            heongpu::keyswitching_type::KEYSWITHING_METHOD_I,
+            heongpu::keyswitching_type::KEYSWITCHING_METHOD_I,
             heongpu::sec_level_type::none);
         context.set_poly_modulus_degree(poly_modulus_degree);
         context.set_coeff_modulus({40, 30, 30, 30, 30}, {40});
@@ -182,7 +182,7 @@ TEST(HEonGPU, CKKS_Ciphertext_Ciphertext_Addition)
         size_t poly_modulus_degree = 16384;
         heongpu::Parameters context(
             heongpu::scheme_type::ckks,
-            heongpu::keyswitching_type::KEYSWITHING_METHOD_I,
+            heongpu::keyswitching_type::KEYSWITCHING_METHOD_I,
             heongpu::sec_level_type::none);
         context.set_poly_modulus_degree(poly_modulus_degree);
         context.set_coeff_modulus(
@@ -254,7 +254,7 @@ TEST(HEonGPU, CKKS_Ciphertext_Ciphertext_Addition)
         size_t poly_modulus_degree = 32768;
         heongpu::Parameters context(
             heongpu::scheme_type::ckks,
-            heongpu::keyswitching_type::KEYSWITHING_METHOD_I,
+            heongpu::keyswitching_type::KEYSWITCHING_METHOD_I,
             heongpu::sec_level_type::none);
         context.set_poly_modulus_degree(poly_modulus_degree);
         context.set_coeff_modulus({59, 40, 40, 40, 40, 40, 40, 40, 40, 40, 40,
@@ -327,7 +327,7 @@ TEST(HEonGPU, CKKS_Ciphertext_Ciphertext_Addition)
         size_t poly_modulus_degree = 65536;
         heongpu::Parameters context(
             heongpu::scheme_type::ckks,
-            heongpu::keyswitching_type::KEYSWITHING_METHOD_I,
+            heongpu::keyswitching_type::KEYSWITCHING_METHOD_I,
             heongpu::sec_level_type::none);
         context.set_poly_modulus_degree(poly_modulus_degree);
         context.set_coeff_modulus({59, 45, 45, 45, 45, 45, 45, 45, 45, 45,
@@ -406,7 +406,7 @@ TEST(HEonGPU, CKKS_Ciphertext_Plaintext_Addition)
         size_t poly_modulus_degree = 4096;
         heongpu::Parameters context(
             heongpu::scheme_type::ckks,
-            heongpu::keyswitching_type::KEYSWITHING_METHOD_I,
+            heongpu::keyswitching_type::KEYSWITCHING_METHOD_I,
             heongpu::sec_level_type::none);
         context.set_poly_modulus_degree(poly_modulus_degree);
         context.set_coeff_modulus({40, 30, 30}, {40});
@@ -471,7 +471,7 @@ TEST(HEonGPU, CKKS_Ciphertext_Plaintext_Addition)
         size_t poly_modulus_degree = 8192;
         heongpu::Parameters context(
             heongpu::scheme_type::ckks,
-            heongpu::keyswitching_type::KEYSWITHING_METHOD_I,
+            heongpu::keyswitching_type::KEYSWITCHING_METHOD_I,
             heongpu::sec_level_type::none);
         context.set_poly_modulus_degree(poly_modulus_degree);
         context.set_coeff_modulus({40, 30, 30, 30, 30}, {40});
@@ -536,7 +536,7 @@ TEST(HEonGPU, CKKS_Ciphertext_Plaintext_Addition)
         size_t poly_modulus_degree = 16384;
         heongpu::Parameters context(
             heongpu::scheme_type::ckks,
-            heongpu::keyswitching_type::KEYSWITHING_METHOD_I,
+            heongpu::keyswitching_type::KEYSWITCHING_METHOD_I,
             heongpu::sec_level_type::none);
         context.set_poly_modulus_degree(poly_modulus_degree);
         context.set_coeff_modulus(
@@ -602,7 +602,7 @@ TEST(HEonGPU, CKKS_Ciphertext_Plaintext_Addition)
         size_t poly_modulus_degree = 32768;
         heongpu::Parameters context(
             heongpu::scheme_type::ckks,
-            heongpu::keyswitching_type::KEYSWITHING_METHOD_I,
+            heongpu::keyswitching_type::KEYSWITCHING_METHOD_I,
             heongpu::sec_level_type::none);
         context.set_poly_modulus_degree(poly_modulus_degree);
         context.set_coeff_modulus({59, 40, 40, 40, 40, 40, 40, 40, 40, 40, 40,
@@ -669,7 +669,7 @@ TEST(HEonGPU, CKKS_Ciphertext_Plaintext_Addition)
         size_t poly_modulus_degree = 65536;
         heongpu::Parameters context(
             heongpu::scheme_type::ckks,
-            heongpu::keyswitching_type::KEYSWITHING_METHOD_I,
+            heongpu::keyswitching_type::KEYSWITCHING_METHOD_I,
             heongpu::sec_level_type::none);
         context.set_poly_modulus_degree(poly_modulus_degree);
         context.set_coeff_modulus({59, 45, 45, 45, 45, 45, 45, 45, 45, 45,

--- a/test/test_ckks_encoding.cu
+++ b/test/test_ckks_encoding.cu
@@ -40,7 +40,7 @@ TEST(HEonGPU, CKKS_Encoding_Decoding)
         size_t poly_modulus_degree = 4096;
         heongpu::Parameters context(
             heongpu::scheme_type::ckks,
-            heongpu::keyswitching_type::KEYSWITHING_METHOD_I,
+            heongpu::keyswitching_type::KEYSWITCHING_METHOD_I,
             heongpu::sec_level_type::none);
         context.set_poly_modulus_degree(poly_modulus_degree);
         context.set_coeff_modulus({40, 30, 30}, {40});
@@ -85,7 +85,7 @@ TEST(HEonGPU, CKKS_Encoding_Decoding)
         size_t poly_modulus_degree = 8192;
         heongpu::Parameters context(
             heongpu::scheme_type::ckks,
-            heongpu::keyswitching_type::KEYSWITHING_METHOD_I,
+            heongpu::keyswitching_type::KEYSWITCHING_METHOD_I,
             heongpu::sec_level_type::none);
         context.set_poly_modulus_degree(poly_modulus_degree);
         context.set_coeff_modulus({40, 30, 30, 30, 30}, {40});
@@ -130,7 +130,7 @@ TEST(HEonGPU, CKKS_Encoding_Decoding)
         size_t poly_modulus_degree = 16384;
         heongpu::Parameters context(
             heongpu::scheme_type::ckks,
-            heongpu::keyswitching_type::KEYSWITHING_METHOD_I,
+            heongpu::keyswitching_type::KEYSWITCHING_METHOD_I,
             heongpu::sec_level_type::none);
         context.set_poly_modulus_degree(poly_modulus_degree);
         context.set_coeff_modulus(
@@ -176,7 +176,7 @@ TEST(HEonGPU, CKKS_Encoding_Decoding)
         size_t poly_modulus_degree = 32768;
         heongpu::Parameters context(
             heongpu::scheme_type::ckks,
-            heongpu::keyswitching_type::KEYSWITHING_METHOD_I,
+            heongpu::keyswitching_type::KEYSWITCHING_METHOD_I,
             heongpu::sec_level_type::none);
         context.set_poly_modulus_degree(poly_modulus_degree);
         context.set_coeff_modulus({59, 40, 40, 40, 40, 40, 40, 40, 40, 40, 40,
@@ -223,7 +223,7 @@ TEST(HEonGPU, CKKS_Encoding_Decoding)
         size_t poly_modulus_degree = 65536;
         heongpu::Parameters context(
             heongpu::scheme_type::ckks,
-            heongpu::keyswitching_type::KEYSWITHING_METHOD_I,
+            heongpu::keyswitching_type::KEYSWITCHING_METHOD_I,
             heongpu::sec_level_type::none);
         context.set_poly_modulus_degree(poly_modulus_degree);
         context.set_coeff_modulus({59, 45, 45, 45, 45, 45, 45, 45, 45, 45,

--- a/test/test_ckks_encryption.cu
+++ b/test/test_ckks_encryption.cu
@@ -40,7 +40,7 @@ TEST(HEonGPU, CKKS_Encryption_Decryption)
         size_t poly_modulus_degree = 4096;
         heongpu::Parameters context(
             heongpu::scheme_type::ckks,
-            heongpu::keyswitching_type::KEYSWITHING_METHOD_I,
+            heongpu::keyswitching_type::KEYSWITCHING_METHOD_I,
             heongpu::sec_level_type::none);
         context.set_poly_modulus_degree(poly_modulus_degree);
         context.set_coeff_modulus({40, 30, 30}, {40});
@@ -89,7 +89,7 @@ TEST(HEonGPU, CKKS_Encryption_Decryption)
         size_t poly_modulus_degree = 8192;
         heongpu::Parameters context(
             heongpu::scheme_type::ckks,
-            heongpu::keyswitching_type::KEYSWITHING_METHOD_I,
+            heongpu::keyswitching_type::KEYSWITCHING_METHOD_I,
             heongpu::sec_level_type::none);
         context.set_poly_modulus_degree(poly_modulus_degree);
         context.set_coeff_modulus({40, 30, 30, 30, 30}, {40});
@@ -138,7 +138,7 @@ TEST(HEonGPU, CKKS_Encryption_Decryption)
         size_t poly_modulus_degree = 16384;
         heongpu::Parameters context(
             heongpu::scheme_type::ckks,
-            heongpu::keyswitching_type::KEYSWITHING_METHOD_I,
+            heongpu::keyswitching_type::KEYSWITCHING_METHOD_I,
             heongpu::sec_level_type::none);
         context.set_poly_modulus_degree(poly_modulus_degree);
         context.set_coeff_modulus(
@@ -188,7 +188,7 @@ TEST(HEonGPU, CKKS_Encryption_Decryption)
         size_t poly_modulus_degree = 32768;
         heongpu::Parameters context(
             heongpu::scheme_type::ckks,
-            heongpu::keyswitching_type::KEYSWITHING_METHOD_I,
+            heongpu::keyswitching_type::KEYSWITCHING_METHOD_I,
             heongpu::sec_level_type::none);
         context.set_poly_modulus_degree(poly_modulus_degree);
         context.set_coeff_modulus({59, 40, 40, 40, 40, 40, 40, 40, 40, 40, 40,
@@ -239,7 +239,7 @@ TEST(HEonGPU, CKKS_Encryption_Decryption)
         size_t poly_modulus_degree = 65536;
         heongpu::Parameters context(
             heongpu::scheme_type::ckks,
-            heongpu::keyswitching_type::KEYSWITHING_METHOD_I,
+            heongpu::keyswitching_type::KEYSWITCHING_METHOD_I,
             heongpu::sec_level_type::none);
         context.set_poly_modulus_degree(poly_modulus_degree);
         context.set_coeff_modulus({59, 45, 45, 45, 45, 45, 45, 45, 45, 45,

--- a/test/test_ckks_multiplication.cu
+++ b/test/test_ckks_multiplication.cu
@@ -40,7 +40,7 @@ TEST(HEonGPU, CKKS_Ciphertext_Ciphertext_Multiplication_with_Relinearization)
         size_t poly_modulus_degree = 4096;
         heongpu::Parameters context(
             heongpu::scheme_type::ckks,
-            heongpu::keyswitching_type::KEYSWITHING_METHOD_I,
+            heongpu::keyswitching_type::KEYSWITCHING_METHOD_I,
             heongpu::sec_level_type::none);
         context.set_poly_modulus_degree(poly_modulus_degree);
         context.set_coeff_modulus({40, 30, 30}, {40});
@@ -113,7 +113,7 @@ TEST(HEonGPU, CKKS_Ciphertext_Ciphertext_Multiplication_with_Relinearization)
         size_t poly_modulus_degree = 8192;
         heongpu::Parameters context(
             heongpu::scheme_type::ckks,
-            heongpu::keyswitching_type::KEYSWITHING_METHOD_I,
+            heongpu::keyswitching_type::KEYSWITCHING_METHOD_I,
             heongpu::sec_level_type::none);
         context.set_poly_modulus_degree(poly_modulus_degree);
         context.set_coeff_modulus({40, 30, 30, 30, 30}, {40});
@@ -186,7 +186,7 @@ TEST(HEonGPU, CKKS_Ciphertext_Ciphertext_Multiplication_with_Relinearization)
         size_t poly_modulus_degree = 16384;
         heongpu::Parameters context(
             heongpu::scheme_type::ckks,
-            heongpu::keyswitching_type::KEYSWITHING_METHOD_I,
+            heongpu::keyswitching_type::KEYSWITCHING_METHOD_I,
             heongpu::sec_level_type::none);
         context.set_poly_modulus_degree(poly_modulus_degree);
         context.set_coeff_modulus(
@@ -260,7 +260,7 @@ TEST(HEonGPU, CKKS_Ciphertext_Ciphertext_Multiplication_with_Relinearization)
         size_t poly_modulus_degree = 32768;
         heongpu::Parameters context(
             heongpu::scheme_type::ckks,
-            heongpu::keyswitching_type::KEYSWITHING_METHOD_I,
+            heongpu::keyswitching_type::KEYSWITCHING_METHOD_I,
             heongpu::sec_level_type::none);
         context.set_poly_modulus_degree(poly_modulus_degree);
         context.set_coeff_modulus({59, 40, 40, 40, 40, 40, 40, 40, 40, 40, 40,
@@ -335,7 +335,7 @@ TEST(HEonGPU, CKKS_Ciphertext_Ciphertext_Multiplication_with_Relinearization)
         size_t poly_modulus_degree = 65536;
         heongpu::Parameters context(
             heongpu::scheme_type::ckks,
-            heongpu::keyswitching_type::KEYSWITHING_METHOD_I,
+            heongpu::keyswitching_type::KEYSWITCHING_METHOD_I,
             heongpu::sec_level_type::none);
         context.set_poly_modulus_degree(poly_modulus_degree);
         context.set_coeff_modulus({59, 45, 45, 45, 45, 45, 45, 45, 45, 45,
@@ -416,7 +416,7 @@ TEST(HEonGPU, CKKS_Ciphertext_Plaintext_Multiplication)
         size_t poly_modulus_degree = 4096;
         heongpu::Parameters context(
             heongpu::scheme_type::ckks,
-            heongpu::keyswitching_type::KEYSWITHING_METHOD_I,
+            heongpu::keyswitching_type::KEYSWITCHING_METHOD_I,
             heongpu::sec_level_type::none);
         context.set_poly_modulus_degree(poly_modulus_degree);
         context.set_coeff_modulus({40, 30, 30}, {40});
@@ -482,7 +482,7 @@ TEST(HEonGPU, CKKS_Ciphertext_Plaintext_Multiplication)
         size_t poly_modulus_degree = 8192;
         heongpu::Parameters context(
             heongpu::scheme_type::ckks,
-            heongpu::keyswitching_type::KEYSWITHING_METHOD_I,
+            heongpu::keyswitching_type::KEYSWITCHING_METHOD_I,
             heongpu::sec_level_type::none);
         context.set_poly_modulus_degree(poly_modulus_degree);
         context.set_coeff_modulus({40, 30, 30, 30, 30}, {40});
@@ -548,7 +548,7 @@ TEST(HEonGPU, CKKS_Ciphertext_Plaintext_Multiplication)
         size_t poly_modulus_degree = 16384;
         heongpu::Parameters context(
             heongpu::scheme_type::ckks,
-            heongpu::keyswitching_type::KEYSWITHING_METHOD_I,
+            heongpu::keyswitching_type::KEYSWITCHING_METHOD_I,
             heongpu::sec_level_type::none);
         context.set_poly_modulus_degree(poly_modulus_degree);
         context.set_coeff_modulus(
@@ -615,7 +615,7 @@ TEST(HEonGPU, CKKS_Ciphertext_Plaintext_Multiplication)
         size_t poly_modulus_degree = 32768;
         heongpu::Parameters context(
             heongpu::scheme_type::ckks,
-            heongpu::keyswitching_type::KEYSWITHING_METHOD_I,
+            heongpu::keyswitching_type::KEYSWITCHING_METHOD_I,
             heongpu::sec_level_type::none);
         context.set_poly_modulus_degree(poly_modulus_degree);
         context.set_coeff_modulus({59, 40, 40, 40, 40, 40, 40, 40, 40, 40, 40,
@@ -683,7 +683,7 @@ TEST(HEonGPU, CKKS_Ciphertext_Plaintext_Multiplication)
         size_t poly_modulus_degree = 65536;
         heongpu::Parameters context(
             heongpu::scheme_type::ckks,
-            heongpu::keyswitching_type::KEYSWITHING_METHOD_I,
+            heongpu::keyswitching_type::KEYSWITCHING_METHOD_I,
             heongpu::sec_level_type::none);
         context.set_poly_modulus_degree(poly_modulus_degree);
         context.set_coeff_modulus({59, 45, 45, 45, 45, 45, 45, 45, 45, 45,

--- a/test/test_ckks_relinearization.cu
+++ b/test/test_ckks_relinearization.cu
@@ -40,7 +40,7 @@ TEST(HEonGPU, CKKS_Relinearization_Keyswitching_Method_I)
         size_t poly_modulus_degree = 4096;
         heongpu::Parameters context(
             heongpu::scheme_type::ckks,
-            heongpu::keyswitching_type::KEYSWITHING_METHOD_I,
+            heongpu::keyswitching_type::KEYSWITCHING_METHOD_I,
             heongpu::sec_level_type::none);
         context.set_poly_modulus_degree(poly_modulus_degree);
         context.set_coeff_modulus({40, 30, 30}, {40});
@@ -113,7 +113,7 @@ TEST(HEonGPU, CKKS_Relinearization_Keyswitching_Method_I)
         size_t poly_modulus_degree = 8192;
         heongpu::Parameters context(
             heongpu::scheme_type::ckks,
-            heongpu::keyswitching_type::KEYSWITHING_METHOD_I,
+            heongpu::keyswitching_type::KEYSWITCHING_METHOD_I,
             heongpu::sec_level_type::none);
         context.set_poly_modulus_degree(poly_modulus_degree);
         context.set_coeff_modulus({40, 30, 30, 30, 30}, {40});
@@ -186,7 +186,7 @@ TEST(HEonGPU, CKKS_Relinearization_Keyswitching_Method_I)
         size_t poly_modulus_degree = 16384;
         heongpu::Parameters context(
             heongpu::scheme_type::ckks,
-            heongpu::keyswitching_type::KEYSWITHING_METHOD_I,
+            heongpu::keyswitching_type::KEYSWITCHING_METHOD_I,
             heongpu::sec_level_type::none);
         context.set_poly_modulus_degree(poly_modulus_degree);
         context.set_coeff_modulus(
@@ -260,7 +260,7 @@ TEST(HEonGPU, CKKS_Relinearization_Keyswitching_Method_I)
         size_t poly_modulus_degree = 32768;
         heongpu::Parameters context(
             heongpu::scheme_type::ckks,
-            heongpu::keyswitching_type::KEYSWITHING_METHOD_I,
+            heongpu::keyswitching_type::KEYSWITCHING_METHOD_I,
             heongpu::sec_level_type::none);
         context.set_poly_modulus_degree(poly_modulus_degree);
         context.set_coeff_modulus({59, 40, 40, 40, 40, 40, 40, 40, 40, 40, 40,
@@ -335,7 +335,7 @@ TEST(HEonGPU, CKKS_Relinearization_Keyswitching_Method_I)
         size_t poly_modulus_degree = 65536;
         heongpu::Parameters context(
             heongpu::scheme_type::ckks,
-            heongpu::keyswitching_type::KEYSWITHING_METHOD_I,
+            heongpu::keyswitching_type::KEYSWITCHING_METHOD_I,
             heongpu::sec_level_type::none);
         context.set_poly_modulus_degree(poly_modulus_degree);
         context.set_coeff_modulus({59, 45, 45, 45, 45, 45, 45, 45, 45, 45,
@@ -416,7 +416,7 @@ TEST(HEonGPU, CKKS_Relinearization_Keyswitching_Method_II)
         size_t poly_modulus_degree = 4096;
         heongpu::Parameters context(
             heongpu::scheme_type::ckks,
-            heongpu::keyswitching_type::KEYSWITHING_METHOD_II,
+            heongpu::keyswitching_type::KEYSWITCHING_METHOD_II,
             heongpu::sec_level_type::none);
         context.set_poly_modulus_degree(poly_modulus_degree);
         context.set_coeff_modulus({40, 30, 30}, {40, 40});
@@ -489,7 +489,7 @@ TEST(HEonGPU, CKKS_Relinearization_Keyswitching_Method_II)
         size_t poly_modulus_degree = 8192;
         heongpu::Parameters context(
             heongpu::scheme_type::ckks,
-            heongpu::keyswitching_type::KEYSWITHING_METHOD_II,
+            heongpu::keyswitching_type::KEYSWITCHING_METHOD_II,
             heongpu::sec_level_type::none);
         context.set_poly_modulus_degree(poly_modulus_degree);
         context.set_coeff_modulus({40, 30, 30, 30, 30}, {40, 40});
@@ -562,7 +562,7 @@ TEST(HEonGPU, CKKS_Relinearization_Keyswitching_Method_II)
         size_t poly_modulus_degree = 16384;
         heongpu::Parameters context(
             heongpu::scheme_type::ckks,
-            heongpu::keyswitching_type::KEYSWITHING_METHOD_II,
+            heongpu::keyswitching_type::KEYSWITCHING_METHOD_II,
             heongpu::sec_level_type::none);
         context.set_poly_modulus_degree(poly_modulus_degree);
         context.set_coeff_modulus(
@@ -636,7 +636,7 @@ TEST(HEonGPU, CKKS_Relinearization_Keyswitching_Method_II)
         size_t poly_modulus_degree = 32768;
         heongpu::Parameters context(
             heongpu::scheme_type::ckks,
-            heongpu::keyswitching_type::KEYSWITHING_METHOD_II,
+            heongpu::keyswitching_type::KEYSWITCHING_METHOD_II,
             heongpu::sec_level_type::none);
         context.set_poly_modulus_degree(poly_modulus_degree);
         context.set_coeff_modulus({59, 40, 40, 40, 40, 40, 40, 40, 40, 40, 40,
@@ -711,7 +711,7 @@ TEST(HEonGPU, CKKS_Relinearization_Keyswitching_Method_II)
         size_t poly_modulus_degree = 65536;
         heongpu::Parameters context(
             heongpu::scheme_type::ckks,
-            heongpu::keyswitching_type::KEYSWITHING_METHOD_II,
+            heongpu::keyswitching_type::KEYSWITCHING_METHOD_II,
             heongpu::sec_level_type::none);
         context.set_poly_modulus_degree(poly_modulus_degree);
         context.set_coeff_modulus({59, 45, 45, 45, 45, 45, 45, 45, 45, 45,

--- a/test/test_ckks_rotation_method_1_part_1.cu
+++ b/test/test_ckks_rotation_method_1_part_1.cu
@@ -40,7 +40,7 @@ TEST(HEonGPU, BFV_Ciphertext_Rotation_Keyswitching_Method_I_Part_I)
         size_t poly_modulus_degree = 4096;
         heongpu::Parameters context(
             heongpu::scheme_type::ckks,
-            heongpu::keyswitching_type::KEYSWITHING_METHOD_I,
+            heongpu::keyswitching_type::KEYSWITCHING_METHOD_I,
             heongpu::sec_level_type::none);
         context.set_poly_modulus_degree(poly_modulus_degree);
         context.set_coeff_modulus({40, 30, 30}, {40});
@@ -104,7 +104,7 @@ TEST(HEonGPU, BFV_Ciphertext_Rotation_Keyswitching_Method_I_Part_I)
         size_t poly_modulus_degree = 8192;
         heongpu::Parameters context(
             heongpu::scheme_type::ckks,
-            heongpu::keyswitching_type::KEYSWITHING_METHOD_I,
+            heongpu::keyswitching_type::KEYSWITCHING_METHOD_I,
             heongpu::sec_level_type::none);
         context.set_poly_modulus_degree(poly_modulus_degree);
         context.set_coeff_modulus({40, 30, 30, 30, 30}, {40});
@@ -168,7 +168,7 @@ TEST(HEonGPU, BFV_Ciphertext_Rotation_Keyswitching_Method_I_Part_I)
         size_t poly_modulus_degree = 16384;
         heongpu::Parameters context(
             heongpu::scheme_type::ckks,
-            heongpu::keyswitching_type::KEYSWITHING_METHOD_I,
+            heongpu::keyswitching_type::KEYSWITCHING_METHOD_I,
             heongpu::sec_level_type::none);
         context.set_poly_modulus_degree(poly_modulus_degree);
         context.set_coeff_modulus(

--- a/test/test_ckks_rotation_method_1_part_2.cu
+++ b/test/test_ckks_rotation_method_1_part_2.cu
@@ -40,7 +40,7 @@ TEST(HEonGPU, BFV_Ciphertext_Rotation_Keyswitching_Method_I_Part_I)
         size_t poly_modulus_degree = 32768;
         heongpu::Parameters context(
             heongpu::scheme_type::ckks,
-            heongpu::keyswitching_type::KEYSWITHING_METHOD_I,
+            heongpu::keyswitching_type::KEYSWITCHING_METHOD_I,
             heongpu::sec_level_type::none);
         context.set_poly_modulus_degree(poly_modulus_degree);
         context.set_coeff_modulus({59, 40, 40, 40, 40, 40, 40, 40, 40, 40, 40,

--- a/test/test_ckks_rotation_method_1_part_3.cu
+++ b/test/test_ckks_rotation_method_1_part_3.cu
@@ -41,7 +41,7 @@ TEST(HEonGPU, BFV_Ciphertext_Rotation_Keyswitching_Method_I_Part_II)
         // TODO: find optimal way to store huge galois key, maybe store it in
         // CPU RAM.
         // heongpu::Parameters context(heongpu::scheme_type::ckks,
-        // heongpu::keyswitching_type::KEYSWITHING_METHOD_I,
+        // heongpu::keyswitching_type::KEYSWITCHING_METHOD_I,
         // heongpu::sec_level_type::none);
         // context.set_poly_modulus_degree(poly_modulus_degree);
         // context.set_coeff_modulus({59, 45, 45, 45, 45, 45, 45, 45, 45, 45,
@@ -52,7 +52,7 @@ TEST(HEonGPU, BFV_Ciphertext_Rotation_Keyswitching_Method_I_Part_II)
         // context.generate();
         heongpu::Parameters context(
             heongpu::scheme_type::ckks,
-            heongpu::keyswitching_type::KEYSWITHING_METHOD_I,
+            heongpu::keyswitching_type::KEYSWITCHING_METHOD_I,
             heongpu::sec_level_type::none);
         context.set_poly_modulus_degree(poly_modulus_degree);
         context.set_coeff_modulus(

--- a/test/test_ckks_rotation_method_2_part_1.cu
+++ b/test/test_ckks_rotation_method_2_part_1.cu
@@ -40,7 +40,7 @@ TEST(HEonGPU, BFV_Ciphertext_Rotation_Keyswitching_Method_II_Part_I)
         size_t poly_modulus_degree = 4096;
         heongpu::Parameters context(
             heongpu::scheme_type::ckks,
-            heongpu::keyswitching_type::KEYSWITHING_METHOD_II,
+            heongpu::keyswitching_type::KEYSWITCHING_METHOD_II,
             heongpu::sec_level_type::none);
         context.set_poly_modulus_degree(poly_modulus_degree);
         context.set_coeff_modulus({40, 30, 30}, {40, 40});
@@ -104,7 +104,7 @@ TEST(HEonGPU, BFV_Ciphertext_Rotation_Keyswitching_Method_II_Part_I)
         size_t poly_modulus_degree = 8192;
         heongpu::Parameters context(
             heongpu::scheme_type::ckks,
-            heongpu::keyswitching_type::KEYSWITHING_METHOD_II,
+            heongpu::keyswitching_type::KEYSWITCHING_METHOD_II,
             heongpu::sec_level_type::none);
         context.set_poly_modulus_degree(poly_modulus_degree);
         context.set_coeff_modulus({40, 30, 30, 30, 30}, {40, 40});
@@ -168,7 +168,7 @@ TEST(HEonGPU, BFV_Ciphertext_Rotation_Keyswitching_Method_II_Part_I)
         size_t poly_modulus_degree = 16384;
         heongpu::Parameters context(
             heongpu::scheme_type::ckks,
-            heongpu::keyswitching_type::KEYSWITHING_METHOD_II,
+            heongpu::keyswitching_type::KEYSWITCHING_METHOD_II,
             heongpu::sec_level_type::none);
         context.set_poly_modulus_degree(poly_modulus_degree);
         context.set_coeff_modulus(

--- a/test/test_ckks_rotation_method_2_part_2.cu
+++ b/test/test_ckks_rotation_method_2_part_2.cu
@@ -40,7 +40,7 @@ TEST(HEonGPU, BFV_Ciphertext_Rotation_Keyswitching_Method_II_Part_I)
         size_t poly_modulus_degree = 32768;
         heongpu::Parameters context(
             heongpu::scheme_type::ckks,
-            heongpu::keyswitching_type::KEYSWITHING_METHOD_II,
+            heongpu::keyswitching_type::KEYSWITCHING_METHOD_II,
             heongpu::sec_level_type::none);
         context.set_poly_modulus_degree(poly_modulus_degree);
         context.set_coeff_modulus({59, 40, 40, 40, 40, 40, 40, 40, 40, 40, 40,

--- a/test/test_ckks_rotation_method_2_part_3.cu
+++ b/test/test_ckks_rotation_method_2_part_3.cu
@@ -41,7 +41,7 @@ TEST(HEonGPU, BFV_Ciphertext_Rotation_Keyswitching_Method_I_Part_II)
         // TODO: find optimal way to store huge galois key, maybe store it in
         // CPU RAM.
         // heongpu::Parameters context(heongpu::scheme_type::ckks,
-        // heongpu::keyswitching_type::KEYSWITHING_METHOD_II,
+        // heongpu::keyswitching_type::KEYSWITCHING_METHOD_II,
         // heongpu::sec_level_type::none);
         // context.set_poly_modulus_degree(poly_modulus_degree);
         // context.set_coeff_modulus({59, 45, 45, 45, 45, 45, 45, 45, 45, 45,
@@ -52,7 +52,7 @@ TEST(HEonGPU, BFV_Ciphertext_Rotation_Keyswitching_Method_I_Part_II)
         // context.generate();
         heongpu::Parameters context(
             heongpu::scheme_type::ckks,
-            heongpu::keyswitching_type::KEYSWITHING_METHOD_II,
+            heongpu::keyswitching_type::KEYSWITCHING_METHOD_II,
             heongpu::sec_level_type::none);
         context.set_poly_modulus_degree(poly_modulus_degree);
         context.set_coeff_modulus(


### PR DESCRIPTION
The keyswitching_type enum had wrong spelling for its variables,
keyswitching was spelled as keyswithing.
