### PR TITLE
Fix serializer compilation. Use stdint to access uint8_t

### DIFF
--- a/src/heongpu/include/util/serializer.h
+++ b/src/heongpu/include/util/serializer.h
@@ -14,6 +14,7 @@
 #include <fstream>
 #include <string>
 #include <stdexcept>
+#include <stdint.h>
 #include <zlib.h>
 
 namespace heongpu


### PR DESCRIPTION
I was unable to compile without this change. Perhaps there is a better way?

Here is my environment:

```
$ gcc --version
gcc (Ubuntu 13.3.0-6ubuntu2~24.04) 13.3.0
...

$ cmake --version
cmake version 4.0.2
...
```